### PR TITLE
Improve the measure to force the search without keyword. 

### DIFF
--- a/search-filter.php
+++ b/search-filter.php
@@ -1040,9 +1040,16 @@ if ( ! class_exists( 'SearchAndFilter' ) )
 			if($this->has_form_posted)
 			{//if the search has been posted, redirect to the newly formed url with all the right params
 			
-				if($this->urlparams=="/")
+				if (!strpos($this->urlparams, "?s=")) 
 				{//check to see if url params are set, if not ("/") then add "?s=" to force load search results, without this it would redirect to the homepage, which may be a custom page with no blog items/results
-					$this->urlparams .= "?s=";
+					if (strpos($this->urlparams, "?")) 
+					{
+						$this->urlparams = str_replace("?", "?s=&", $this->urlparams);
+					} 
+					else 
+					{
+						$this->urlparams .= "?s=";
+					}
 				}
 				
 				if($this->urlparams=="/?s=")


### PR DESCRIPTION
With the actual code, if I create a form setting the "post_type", the search without keyword fail because the post type is set in the URL and the code doesn't include the "?s=".

This is my form
![widgets telecentre europe wordpress 2016-04-11 10-14-34](https://cloud.githubusercontent.com/assets/365699/14420873/b63978be-ffce-11e5-8d77-cd60edc32f28.png)
