### PR TITLE
Suggested update to allow for CSS only custom checkboxes

### DIFF
--- a/of-taxonomy-walker.php
+++ b/of-taxonomy-walker.php
@@ -133,7 +133,7 @@ class Taxonomy_Walker extends Walker_Category {
 				}
 			}
 			
-			$link = "<label><input type='".$this->type."' name='".$name."[]' value='".$cat_id."'".$checked." /> ".$cat_name;
+			$link = "<input type='".$this->type."' name='".$sf_name."[]' value='".$cat_id."'".$checked." id='cat-id-" . $cat_id . "' /> <label for='cat-id-" . $cat_id . "'>".$cat_name;
 
 			
 			if ( !empty($show_count) )


### PR DESCRIPTION
Hello,

Love your plugin so far. I found myself making game-time adjustments to allow for custom checkboxes which I prefer to do with CSS only. However, this is only possible if the html structure is such that the label follows the checkbox input, and the label has a "for" attribute which matches the input id attribute. If you're unfamiliar with the technique, here is an article that does a good job of covering it:
https://medium.com/claritydesignsystem/pure-css-accessible-checkboxes-and-radios-buttons-54063e759bb3

I've provided one possible solution for this idea. If you have any objections or suggestions please let me know so I can update my code.

My hope is that you'll integrate this suggestion and I can keep my plugin on the main stream vs having a custom plugin to maintain.